### PR TITLE
Bundle required flags only

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,60 @@ const JustAFlag = () =>
 ```
 
 ### Props  
+#### from (optional)
+#### Type: `{}`
+#### Default value: `await import('./flags')` (all available flags).
+The flags you want to use.
+
+By default, [all available flags](https://github.com/frostney/react-native-flags/blob/master/flags/index.js) are bundled/imported.
+However, *bundling all flags is discouraged*, because you might not need all of them.
+Instead, you could import your flags beforehand and use this prop to pass your flags.
+
+Below are a few examples:
+
+Load all flat 32 flags:
+```javascript
+import Flag from 'react-native-flags';
+import * as allFlatFlags32 from 'react-native-flags/flags/flat/32';
+
+const JustAFlag = ({ code }) =>
+  <Flag
+    from={allFlatFlags32}
+    code={code}
+    size={32}
+    type="flat"
+  />
+```
+
+Load all shiny 16/24/32/48/64 flags:
+```javascript
+import Flag from 'react-native-flags';
+import * as allShinyFlags from 'react-native-flags/flags/shiny';
+
+const JustAFlag = ({ code, size }) =>
+  <Flag
+    from={allShinyFlags}
+    code={code}
+    size={size}
+    type="shiny"
+  />
+```
+
+Load all flat/shiny 16/24/32/48/64 flags.
+This is the same as removing the `from` prop:
+```javascript
+import Flag from 'react-native-flags';
+import * as allFlags from 'react-native-flags/flags';
+
+const JustAFlag = ({ code, size, type }) =>
+  <Flag
+    from={allFlags}
+    code={code}
+    size={size}
+    type={type}
+  />
+```
+
 #### code  
 #### Type: `String`  
 The ISO code of a flag, for example "DE", "FR" or "GB"

--- a/index.js
+++ b/index.js
@@ -11,6 +11,23 @@ type Props = {
   style?: any,
 };
 
+/**
+ * Find a flag exported from ./flags' sub-directories
+ * (or directories that match the same structure)
+ * and return it.
+ *
+ * @example
+ * import * as flags from './flags';
+ * import * as flatFlags from './flags/flat';
+ * import * as flatFlags16 from './flags/flat/16';
+ *
+ * const emptyFlags = {};
+ * const props = { type: 'flat', size: 16, code: 'ZW' };
+ * 
+ * getFlag(flatFlags16, props) === getFlag(flatFlags, props); // > true
+ * getFlag(flatFlags, props) === getFlag(flags, props); // > true
+ * getFlag(emptyFlags, props); // > null
+ */
 const getFlag = (flags: {}, { type, size, code }: {
   type: string,
   size: number,
@@ -18,7 +35,14 @@ const getFlag = (flags: {}, { type, size, code }: {
 }) => {
   const sizeKey = `icons${size}`;
 
-  return flags[type][sizeKey][code];
+  return (type in flags // ./flags was imported.
+    ? flags[type][sizeKey][code]
+    : sizeKey in flags // ./flags/{type} was imported.
+    ? flags[sizeKey][code]
+    : code in flags // ./flags/{type}/{size} was imported.
+    ? flags[code]
+    : null
+  );
 };
 
 const Flag = ({ from, size = 64, code, type = 'shiny', style }: Props) => {

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from 'react';
 import { Image } from 'react-native';
 
 type Props = {
+  from?: {},
   size: 16 | 24 | 32 | 48 | 64,
   code: string,
   type?: 'flat' | 'shiny',
@@ -20,7 +21,7 @@ const getFlag = (flags: {}, { type, size, code }: {
   return flags[type][sizeKey][code];
 };
 
-const Flag = ({ size = 64, code, type = 'shiny', style }: Props) => {
+const Flag = ({ from, size = 64, code, type = 'shiny', style }: Props) => {
   // @TODO Set an initial value.
   const [source, setSource] = useState();
 
@@ -29,7 +30,8 @@ const Flag = ({ size = 64, code, type = 'shiny', style }: Props) => {
     let isMounted = true;
 
     (async () => {
-      const flags = await import('./flags');
+      // Use our flags or import all of them.
+      const flags = from || await import('./flags');
       const flag = getFlag(flags, { type, size, code });
       const unknownFlag = getFlag(flags, { type, size, code: 'unknown' });
 
@@ -43,7 +45,7 @@ const Flag = ({ size = 64, code, type = 'shiny', style }: Props) => {
       // @TODO Abort import instead.
       isMounted = false;
     };
-  }, [type, size, code, setSource]);
+  }, [from, type, size, code, setSource]);
 
   return (
     <Image

--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 // @flow
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Image } from 'react-native';
-import * as flags from './flags';
 
 type Props = {
   size: 16 | 24 | 32 | 48 | 64,
@@ -12,12 +11,33 @@ type Props = {
 };
 
 const Flag = ({ size = 64, code, type = 'shiny', style }: Props) => {
-  const flag = flags[type][`icons${size}`][code];
-  const unknownFlag = flags[type][`icons${size}`]['unknown'];
+  // @TODO Set an initial value.
+  const [source, setSource] = useState();
+
+  // Load flags asynchronously.
+  useEffect(() => {
+    let isMounted = true;
+
+    (async () => {
+      const flags = await import('./flags');
+      const flag = flags[type][`icons${size}`][code];
+      const unknownFlag = flags[type][`icons${size}`]['unknown'];
+
+      if (isMounted) {
+        setSource(flag || unknownFlag);
+      }
+    })();
+
+    return () => {
+      // Anti-pattern.
+      // @TODO Abort import instead.
+      isMounted = false;
+    };
+  }, [type, size, code, setSource]);
 
   return (
     <Image
-      source={flag || unknownFlag}
+      source={source}
       style={[{ width: size, height: size }, style]}
     />
   );

--- a/index.js
+++ b/index.js
@@ -10,6 +10,16 @@ type Props = {
   style?: any,
 };
 
+const getFlag = (flags: {}, { type, size, code }: {
+  type: string,
+  size: number,
+  code: string
+}) => {
+  const sizeKey = `icons${size}`;
+
+  return flags[type][sizeKey][code];
+};
+
 const Flag = ({ size = 64, code, type = 'shiny', style }: Props) => {
   // @TODO Set an initial value.
   const [source, setSource] = useState();
@@ -20,8 +30,8 @@ const Flag = ({ size = 64, code, type = 'shiny', style }: Props) => {
 
     (async () => {
       const flags = await import('./flags');
-      const flag = flags[type][`icons${size}`][code];
-      const unknownFlag = flags[type][`icons${size}`]['unknown'];
+      const flag = getFlag(flags, { type, size, code });
+      const unknownFlag = getFlag(flags, { type, size, code: 'unknown' });
 
       if (isMounted) {
         setSource(flag || unknownFlag);


### PR DESCRIPTION
Hi, @frostney! How's it going?

I made some changes to your code to avoid bundling/importing all flags when using this component, and import only the required flags, to minimize bundle size.

I know it's been a while since you made this, but I'd be great if this gets released someday.

Basically, these changes allow importing flags beforehand and passing them using the `from` param. To do that:
- A new param was added, called `from`. This is not a path, it's an optional object that is intended to contain exported flags/images from the `./flags` sub-directories, like `./flags`, `./flags/flat`, `./flags/shiny/16`, etc. This doesn't affect previous versions.
- Flags are not imported at the top, but rather at runtime (using import() inside a useEffect hook) only if `from` is not present. This might affect previous versions, but I don't think so.

Hopefully these changes are understandable and easy to read. I added some examples in the `readme` file, and in the code too (just in case). If you need something else, please tell me. I'll be glad to help.

Have a nice day, and thank you releasing this project!